### PR TITLE
fix(types): make constructor argument optional

### DIFF
--- a/src/webpackbar.ts
+++ b/src/webpackbar.ts
@@ -33,7 +33,7 @@ export default class WebpackBarPlugin extends ProgressPlugin {
   private options: any
   private reporters: Reporter[]
 
-  constructor (options: WebpackBarOptions) {
+  constructor (options?: WebpackBarOptions) {
     super({ activeModules: true })
 
     this.options = Object.assign({}, DEFAULTS, options)


### PR DESCRIPTION
The code treats `undefined` the same as `{}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nuxt-contrib/webpackbar/80)
<!-- Reviewable:end -->
